### PR TITLE
backoff retry + added delay to weekly agg updates

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ class MyClient(discord.Client):
     async def setup_hook(self) -> None:
         self.db_lock = asyncio.Lock()
 
-        # create the background tasks and run it in the background
+        # create the background tasks and run them in the background
         self.notion_creation_task = self.loop.create_task(
             self.notion_creation_notifications()
         )
@@ -24,7 +24,7 @@ class MyClient(discord.Client):
 
         self.notion_aggregate_updates_task = self.loop.create_task(
             self.notion_aggregate_updates_notifications()
-)
+        )
 
     async def on_ready(self):
         logger.info(f"Logged in as {self.user} (ID: {self.user.id})")
@@ -52,14 +52,17 @@ class MyClient(discord.Client):
     async def notion_aggregate_updates_notifications(self):
         await self.wait_until_ready()
 
-        await notion.sync_db(self.db_lock)
+        # Wait for 7 days before the first run
+        logger.info("Waiting 7 days before running aggregate updates for the first time")
+        await asyncio.sleep(7 * 24 * 60 * 60)  # 7 days in seconds
 
         channel = self.get_channel(NOTION_NOTIFICATION_CHANNEL)
-        
+
         while not self.is_closed():
-            await notion.handle_aggregate_updates(channel)
+            await notion.handle_aggregate_updates(channel, self.db_lock)
             logger.info("Notion Aggregate Updates handled")
-            await asyncio.sleep(7 * 24 * 60 * 60) #Run task once a week
+            # Then it will wait for another 7 days before the next run
+            await asyncio.sleep(7 * 24 * 60 * 60) # Run task once a week
 
 
 intents = discord.Intents.default()


### PR DESCRIPTION
Noticed that connections were timing out with a 502 Gateway error.

Added backoff retry.

Noticed agg updates were running everytime bot was initiated.

Added initial 7 day delay from time bot is started.

