### PR TITLE
Time tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Tracking of start time and calculating of time difference to ensure that if bot is restarted aggregate updates are not delayed / missed due to timer resetting.
+
+### Changed
+
+- Frequency in which notion_aggregate_updates_notifications is called within bot.py
+
+## [0.1.0] - 8/12/2023
+
+### Added
+
+- This CHANGELOG file.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Frequency in which notion_aggregate_updates_notifications is called within bot.py
 
-## [0.1.0] - 8/12/2023
-
 ### Added
 
 - This CHANGELOG file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Tracking of start time and calculating of time difference to ensure that if bot is restarted aggregate updates are not delayed / missed due to timer resetting.
+- load_start_time and save_start_time functions functions added to keep track of the bots start time. This handles instances where the bot may be restarted which would previously cause delays and potentially missed aggregate updates.
 
 ### Changed
 

--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from constants import NOTION_NOTIFICATION_CHANNEL
 
 
 class MyClient(discord.Client):
-    START_TIME_FILE = "start_time.json"
+    START_TIME_FILE = "/bot/start_time.json"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -88,8 +88,10 @@ class MyClient(discord.Client):
         while not self.is_closed():
 
             start_time = self.load_start_time()
+            logger.info(f"Start time: {start_time}")
             if start_time:
                 time_difference = datetime.datetime.utcnow() - start_time
+                logger.info(f"Time difference: {time_difference}")
                 days_passed = time_difference.days
 
                 if days_passed >= 7:
@@ -98,7 +100,6 @@ class MyClient(discord.Client):
 
                     #Reset start time for next 7-day cycle
                     self.save_start_time()
-                    logger.info("Save start time updated")
             await asyncio.sleep(60 * 60 * 48)
 
 intents = discord.Intents.default()

--- a/bot.py
+++ b/bot.py
@@ -98,6 +98,7 @@ class MyClient(discord.Client):
 
                     #Reset start time for next 7-day cycle
                     self.save_start_time()
+                    logger.info("Save start time updated")
             await asyncio.sleep(60 * 24 * 24)
 
 intents = discord.Intents.default()

--- a/bot.py
+++ b/bot.py
@@ -99,7 +99,7 @@ class MyClient(discord.Client):
                     #Reset start time for next 7-day cycle
                     self.save_start_time()
                     logger.info("Save start time updated")
-            await asyncio.sleep(60 * 24 * 24)
+            await asyncio.sleep(60 * 60 * 48)
 
 intents = discord.Intents.default()
 

--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from constants import NOTION_NOTIFICATION_CHANNEL
 
 
 class MyClient(discord.Client):
-    START_TIME_FILE = "/bot/start_time.json"
+    START_TIME_FILE = "./start_time.json"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -100,7 +100,7 @@ class MyClient(discord.Client):
 
                     #Reset start time for next 7-day cycle
                     self.save_start_time()
-            await asyncio.sleep(60 * 60 * 48)
+            await asyncio.sleep(60 * 60 * 24)
 
 intents = discord.Intents.default()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,8 @@ services:
     image: ghcr.io/bloomgamestudio/notiondiscordintegration:main
     restart: unless-stopped
     env_file: .env
+    volumes:
+      - notion_bot_volume:/bot
+
+volumes:
+  notion_bot_volume:


### PR DESCRIPTION
Added functions to load / save start time. 

Updated frequency of notion_aggregate_updates_notifications call to every 2 days to account for any bot resets. Checking weekly makes little sense when we are doing a comparison of time anyway.

If 7 days or more have passed, the handle aggregate updates will be called and the new start time will be saved.

