### PR TITLE
request only default intents

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -31,11 +31,8 @@ def setup_discord_service(
         check_interval=settings.UPDATE_INTERVAL,
     )
 
-    intents = discord.Intents.default()
-    intents.message_content = True
-
     discord_client = DiscordClient(
-        discord_service=discord_service, settings=settings, intents=intents
+        discord_service=discord_service, settings=settings, intents=discord.Intents.default()
     )
 
     return discord_service, discord_client


### PR DESCRIPTION
Since the bot is only posting messages to a specific channel, only default intents are required.

Before merging this in we should be sure to update the `DISCORD_BOT_TOKEN` envar on the staging/prod deployments to the new Bloom Team bot token.

Intents are already set accordingly on [staging app](https://discord.com/developers/applications/1341901099673583759/bot) and [production app](https://discord.com/developers/applications/1341901908713148428/bot).